### PR TITLE
Fix analytics typo

### DIFF
--- a/carbon.sample.simple.txt
+++ b/carbon.sample.simple.txt
@@ -3,7 +3,7 @@
 
 [Upstream Providers]
 
-# while a website might rely on a single provider, it's common to rely on other providers: google for analyics, or another CDN, and so on. Let's assume a simple site is hosted just by one org for this example
+# while a website might rely on a single provider, it's common to rely on other providers: google for analytics, or another CDN, and so on. Let's assume a simple site is hosted just by one org for this example
 
 providers = [<URL for company>]
 


### PR DESCRIPTION
Noticed while adding the format to this site: http://fileformats.archiveteam.org/wiki/Carbon.txt which I hope will boost exposure a little.

Additionally, I'd like to propose reformatting the sample to the minimal markdown line-length standard, 80 chars, to make it easier to read and in line with code-editing IDEs. 

E.g. 

```ini
# we assume most sites have one main provider which might provide the servers 
# used to serve content. If you know this, you can look up that provider's 
# carbon.txt file to make it possible to start walking the graph.

[Upstream Providers]

# while a website might rely on a single provider, it's common to rely on other 
# providers: google for analytics, or another CDN, and so on. Let's assume a 
# simple site is hosted just by one org for this example.

providers = [<URL for company>]

# That's all you need
```