### PR TITLE
Update HTTP and DNS delegation documentation

### DIFF
--- a/examples/server_setup_nginx_via_header.md
+++ b/examples/server_setup_nginx_via_header.md
@@ -1,5 +1,5 @@
 
-## Implementing a `via` HTTP header with Nginx for carbon.txt
+## Implementing a `CarbonTxt-Location` HTTP header with Nginx for carbon.txt
 
 Consider the scenario where you are operate a managed WordPress service with a website at managed-service.com, but you serve your customer's websites at their own domain, like https://downstream-customer.com.
 
@@ -28,62 +28,48 @@ flowchart LR
 Nginx is a powerful tool, but for our purposes, let's assume you have defined a server accordingly, where most of the wordpress specific logic is in a separate file, as it outlined in the guidance on the [WordPress Devhub site](https://wordpress.org/documentation/article/nginx/), but you are serving a single site with a single nginx config file.
 
 ```nginx
- 
+
 server {
     server_name downstream-customer.com;
     root /var/www/downstream-customer.com;
- 
+
     index index.php;
 
     include global/restrictions.conf;
- 
+
     # Assume wordpress specific info goes here
     include global/wordpress.conf;
 
 }
 ```
 
-To add HTTP `Via` header, where you can point to a specific location for a carbon.txt file, you would add the following lines, using the [nginx add_header](https://www.keycdn.com/support/nginx-add_header) directive.
+To add HTTP `CarbonTxt-Location` header, where you can point to a specific location for a carbon.txt file, you would add the following lines, using the [nginx add_header](https://www.keycdn.com/support/nginx-add_header) directive.
 
 
-```nginx    
-    location = /carbon.txt {
-        add_header Via 1.1 https://managed-service.com/carbon.txt <long_generated_domain_hash>;
-    }
+```nginx
+    add_header CarbonTxt-Location https://managed-service.com/carbon.txt;
 ```
 
 
 ```nginx
- 
+
 server {
     server_name downstream-customer.com;
     root /var/www/downstream-customer.com;
- 
+
     index index.php;
 
     include global/restrictions.conf;
- 
+
     # Assume wordpress specific info goes here
     include global/wordpress.conf;
 
-    # extra header added here
-    location = /carbon.txt {
-        add_header Via 1.1 https://managed-service.com/carbon.txt <long_generated_domain_hash>;
-    }
+    add_header CarbonTxt-Location https://managed-service.com/carbon.txt;
 
 }
 ```
 
-### Making the change further upstream at the server level, with a dynamic server
 
-This isn't the only way to make this change. If you know what domain you are serving at the server level, 'behind' a reverse proxy like Nginx, you should also be able to serve the corresponding domain hash - either by fetching it from local lookup of domains and their matching precomputed domain hashes, or by generating it on the fly if you have access to the shared secret available from [the Green Web Foundation Shared Secret endpoint](https://api.thegreenwebfoundation.org/api/v3/carbontxt_shared_secret).
-
-**An example with WordPress:**
-
-In the scenario above, PHP-FPM is running Wordpress, 'behind' Nginx, and WordPress itself can add a `Via` HTTP Headers to HTTP responses too. 
-
-Either via [one of the many HTTP Header plugins available](https://wordpress.org/plugins/), or by adding some custom code using WordPress's own [`send_headers()` hook](https://developer.wordpress.org/reference/hooks/send_headers/).
-
-**Further examples**
+## Further examples
 
 This is an open source repository - if you're looking for specific example, or would like to contribute one, [please open an issue](https://github.com/thegreenwebfoundation/carbon.txt/issues).

--- a/faq/FAQ.md
+++ b/faq/FAQ.md
@@ -39,16 +39,6 @@ We believe that providing a way for hosting providers/managed services to implem
 
 In the long run, we think that demonstrating how we can use existing internet and web standards to make sustainability claims easily discoverable, as well as human and machine readable, will result in a web where it's easier to trust green claims. Not only that, conventions like carbon.txt allows us follow green claims to the supporting evidence used to back them up.
 
-## What would stop me using someone else's carbon.txt file instead?
-
-Domains must be associated to an organisation that is a [verified green hosting provider](https://www.thegreenwebfoundation.org/green-web-datasets/get-verified/) with the Green Web Foundation before they show up as being green. This is to mitigate against bad actors taking credit for the green claims made in another organisation's carbon.txt file.
-
-There are two ways to associate a domain with a verified green hosting provider:
-
-**1. Using domain hashes** - New domains are only automatically recognised as green, and associated to a verified green provider, if there is a matching domain hash available when they are first submitted/checked through the Greencheck API.
-
-**2. Manually** - Green Web Foundation staff can manually create a record for a new domain, and associate with an existing verified green hosting provider.
-
 ## How does this work for globally distributed providers?
 
 The internet is a distributed network by its very nature. And, many hosting providers - especially CDNs and edge compute services - will serve content from locations around the world. Some of these locations could be in regions that run entirely (or almost entirely) on green energy.

--- a/guides/DNS-TXT.md
+++ b/guides/DNS-TXT.md
@@ -1,4 +1,4 @@
-# How to link two domains using DNS TXT records and domain hashes
+# How to link two domains using DNS TXT records
 
 DNS text records are frequently used to help organisations demonstrate they have control over a domain. The DNS TXT record approach follows similar principles.
 
@@ -8,20 +8,14 @@ To do this:
 
    Follow Steps 1 to 4 of the [Getting Started guide](/README.md#getting-started) to create a carbon.txt file for your organisation.
 
-2. **Create a domain hash for the domain you want to show as green**
+3. **Set a DNS record for the domains you want to link back to your main carbon.txt**
 
-   Create a domain hash. This is a SHA256 hash of your shared secret and the domain you want to establish a link to.
-
-   You can complete this step on [our website](https://carbontxt.org/how/digital-services/link-multiple-domains/dns#create-domain-hash).
-
-3. **Set a DNS record for the domains you want to link back to your main carbon.txt, containing the domain hash**
-
-   Add the generated domain hash as a final, optional part of the DNS TXT record defining the domain you want to link back to your main carbon.txt file, along with the location of the carbon.txt file and the generated hash.
+   Add the DNS TXT record for the domain you want to link back to your main carbon.txt file, with the location of the carbon.txt file.
 
    For example: _my-org.com_ also owns _me.my-org.com_. In order to link _me.my-org.com_ to the main carbon.txt file, they would create a TXT record that looks something like:
 
    ```DNS
-   TXT "carbon-txt=https://my-org.com/carbon.txt <generated_domain_hash>"
+   TXT "carbon-txt-location=https://my-org.com/carbon.txt"
    ```
 
    **Note:** you can see an example DNS TXT record for the domain [delegating-with-txt-record.carbontxt.org](https://delegating-with-txt-record.carbontxt.org) using online tools like [nslookup.io](https://www.nslookup.io/domains/delegating-with-txt-record.carbontxt.org/dns-records/txt/)

--- a/guides/DNS-TXT.md
+++ b/guides/DNS-TXT.md
@@ -4,11 +4,11 @@ DNS text records are frequently used to help organisations demonstrate they have
 
 To do this:
 
-1. **Follow the steps above to create your carbon.txt file**
+1. **Create your carbon.txt file**
 
-   Follow Steps 1 to 4 of the [Getting Started guide](/README.md#getting-started) to create a carbon.txt file for your organisation.
+   Follow Steps 1 to 3 of the [Getting Started guide](https://carbontxt.org/quickstart) to create a carbon.txt file for your organisation.
 
-3. **Set a DNS record for the domains you want to link back to your main carbon.txt**
+2. **Set a DNS record for the domains you want to link back to your main carbon.txt**
 
    Add the DNS TXT record for the domain you want to link back to your main carbon.txt file, with the location of the carbon.txt file.
 

--- a/guides/VIA-HEADER.md
+++ b/guides/VIA-HEADER.md
@@ -1,28 +1,20 @@
-# How to link two domains using HTTP Via headers domain hashes
-
+# How to link two domains using HTTP headers
 HTTP requests and responses can contain a number of extra headers, which you can use to send along extra metadata about the server serving the request.
 
-Carbon.txt supports using the [HTTP Via header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/via), to declare that a HTTP response has been sent along by one or more intermediate entities. In our case usually a managed hosting provider.
+Carbon.txt supports using the `CarbonTxt-Location`, to declare that a HTTP response has been sent along by one or more intermediate entities. In our case usually a managed hosting provider.
 
 1. **Follow the steps above to create your carbon.txt file**
 
    Follow Steps 1 to 4 of the [Getting Started guide](/README.md#getting-started) to create a carbon.txt file for your organisation.
 
-2. **Create a domain hash for the domain you want to show as green**
 
-   Create a domain hash. This is a SHA256 hash of your shared secret and the domain you want to establish a link to.
+3. **Set the `CarbonTxt-Location` header on HTTP responses to requests for the domain you want to show as green**
 
-   You can complete this step on [our website](https://carbontxt.org/how/digital-services/link-multiple-domains/via#create-domain-hash)
-
-3. **Set the `via` header on HTTP responses to requests for the domain you want to show as green**
-
-   For example: _my-org.com_ also owns _me.my-org.com_. In order to link _me.my-org.com_ to the main carbon.txt file, when a request comes in for _me.my-org.com_, you would configure the server serving the request to add the following Via header.
+   For example: _my-org.com_ also owns _me.my-org.com_. In order to link _me.my-org.com_ to the main carbon.txt file, when a request comes in for _me.my-org.com_, you would configure the server serving the request to add the following header.
 
    ```HTTP
-    Via: 1.1 https://my-org.com/carbon.txt <generated_domain_hash>
+    CarbonTxt-Location: https://my-org.com/carbon.txt
    ```
-
-   **Note**: the domain hash would be a 64 character hash of me.my-org.com and your shared secret.
 
 We maintain a set of [server config setup examples folder on github](https://github.com/thegreenwebfoundation/carbon.txt/tree/master/examples), for popular open source servers like Nginx, Caddy, Apache, and so on (pull requests gratefully accepted).
 

--- a/guides/VIA-HEADER.md
+++ b/guides/VIA-HEADER.md
@@ -1,14 +1,14 @@
 # How to link two domains using HTTP headers
+
 HTTP requests and responses can contain a number of extra headers, which you can use to send along extra metadata about the server serving the request.
 
 Carbon.txt supports using the `CarbonTxt-Location`, to declare that a HTTP response has been sent along by one or more intermediate entities. In our case usually a managed hosting provider.
 
-1. **Follow the steps above to create your carbon.txt file**
+1. **Create your carbon.txt file**
 
-   Follow Steps 1 to 4 of the [Getting Started guide](/README.md#getting-started) to create a carbon.txt file for your organisation.
+   Follow Steps 1 to 3 of the [Getting Started guide](https://carbontxt.org/quickstart) to create a carbon.txt file for your organisation.
 
-
-3. **Set the `CarbonTxt-Location` header on HTTP responses to requests for the domain you want to show as green**
+2. **Set the `CarbonTxt-Location` header on HTTP responses to requests for the domain you want to show as green**
 
    For example: _my-org.com_ also owns _me.my-org.com_. In order to link _me.my-org.com_ to the main carbon.txt file, when a request comes in for _me.my-org.com_, you would configure the server serving the request to add the following header.
 


### PR DESCRIPTION
In order to match the changes introduced by [ADR 02 - Improved architecture for domain validation and carbon.txt delegation](https://github.com/thegreenwebfoundation/carbon-txt-validator/blob/tc-adr-2-improvements-to-delegation-and-domain-validation/docs/adrs/02_improvements_to_delegation_and_domain_validation.md)

This changes the names of the http header and dns txt record used, and removes all mentions of domain hashes.